### PR TITLE
Auto-connect single discovered device

### DIFF
--- a/lib/network_selection.dart
+++ b/lib/network_selection.dart
@@ -102,7 +102,12 @@ class _NetworkConnectionSectionState extends State<NetworkConnectionSection> {
       _controller.text = addresses.first;
       _discovered = addresses.length > 1 ? addresses.sublist(1) : [];
     });
-    if (_discovered.isNotEmpty) _focusNode.requestFocus();
+
+    if (addresses.length == 1) {
+      await _connectTo(addresses.first);
+    } else if (_discovered.isNotEmpty) {
+      _focusNode.requestFocus();
+    }
   }
 
   Future<void> _showError(String message) async {


### PR DESCRIPTION
## Summary
- connect automatically when MDNS/NSD discovery only returns one device

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af454065c832a937508469d9f7b42