### PR TITLE
Add texture controls with OSC bindings

### DIFF
--- a/lib/send_page.dart
+++ b/lib/send_page.dart
@@ -5,6 +5,7 @@ import 'shape.dart';
 import 'send_color.dart';
 import 'osc_dropdown.dart';
 import 'dac_parameters.dart';
+import 'send_texture.dart';
 
 class SendPage extends StatefulWidget {
   final int pageNumber;
@@ -38,10 +39,7 @@ class _SendPageState extends State<SendPage> with OscAddressMixin {
                 ),
                 LabeledCard(title: 'Shape', child: Shape()),
                 LabeledCard(title: 'Color', child: SendColor()),
-                LabeledCard(
-                  title: 'Texture',
-                  child: const Placeholder(fallbackHeight: 100),
-                ),
+                const LabeledCard(title: 'Texture', child: SendTexture()),
               ],
             ),
           ),

--- a/lib/send_texture.dart
+++ b/lib/send_texture.dart
@@ -1,0 +1,234 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'osc_checkbox.dart';
+import 'numeric_slider.dart';
+import 'osc_widget_binding.dart';
+import 'osc_registry.dart';
+import 'network.dart';
+import 'osc_log.dart';
+
+class AbsoluteOscCheckbox extends StatefulWidget {
+  final String address;
+  const AbsoluteOscCheckbox({super.key, required this.address});
+
+  @override
+  State<AbsoluteOscCheckbox> createState() => _AbsoluteOscCheckboxState();
+}
+
+class _AbsoluteOscCheckboxState extends State<AbsoluteOscCheckbox> {
+  bool _value = false;
+
+  void _listener(List<Object?> args) {
+    if (args.isNotEmpty && args.first is bool) {
+      setState(() => _value = args.first as bool);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        oscLogKey.currentState?.logOscMessage(
+          address: widget.address,
+          arg: args,
+          status: OscStatus.ok,
+          direction: Direction.received,
+          binary: Uint8List(0),
+        );
+      });
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        oscLogKey.currentState?.logOscMessage(
+          address: widget.address,
+          arg: args,
+          status: OscStatus.error,
+          direction: Direction.received,
+          binary: Uint8List(0),
+        );
+      });
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    OscRegistry().registerAddress(widget.address);
+    OscRegistry().registerListener(widget.address, _listener);
+  }
+
+  @override
+  void dispose() {
+    OscRegistry().unregisterListener(widget.address, _listener);
+    super.dispose();
+  }
+
+  void _send(bool val) {
+    context.read<Network>().sendOscMessage(widget.address, [val]);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      oscLogKey.currentState?.logOscMessage(
+        address: widget.address,
+        arg: [val],
+        status: OscStatus.ok,
+        direction: Direction.sent,
+        binary: Uint8List(0),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Checkbox(
+      value: _value,
+      onChanged: (val) {
+        if (val == null) return;
+        setState(() => _value = val);
+        _send(val);
+      },
+    );
+  }
+}
+
+class _FloatArrayEditor extends StatefulWidget {
+  final String segment;
+  final int length;
+  const _FloatArrayEditor({required this.segment, required this.length});
+
+  @override
+  State<_FloatArrayEditor> createState() => _FloatArrayEditorState();
+}
+
+class _FloatArrayEditorState extends State<_FloatArrayEditor>
+    with OscAddressMixin {
+  late final List<double> _values = List.filled(widget.length, 0.0);
+  late final List<GlobalKey<NumericSliderState>> _keys = List.generate(
+    widget.length,
+    (_) => GlobalKey<NumericSliderState>(),
+  );
+
+  @override
+  OscStatus onOscMessage(List<Object?> args) {
+    if (args.length >= widget.length &&
+        args.take(widget.length).every((e) => e is num)) {
+      for (int i = 0; i < widget.length; i++) {
+        final v = (args[i] as num).toDouble();
+        _values[i] = v;
+        _keys[i].currentState?.setValue(v, immediate: true);
+      }
+      return OscStatus.ok;
+    }
+    return OscStatus.error;
+  }
+
+  void _onChanged(int idx, double v) {
+    _values[idx] = v;
+    sendOsc(_values);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return OscPathSegment(
+      segment: widget.segment,
+      child: Wrap(
+        spacing: 4,
+        runSpacing: 4,
+        children: List.generate(widget.length, (i) {
+          return SizedBox(
+            width: 60,
+            height: 24,
+            child: NumericSlider(
+              key: _keys[i],
+              value: _values[i],
+              range: const RangeValues(0, 1),
+              precision: 3,
+              onChanged: (v) => _onChanged(i, v),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class SendTexture extends StatelessWidget {
+  const SendTexture({super.key});
+
+  Widget _sliderRow(
+    String label,
+    String segment,
+    GlobalKey<NumericSliderState> key,
+  ) {
+    return Row(
+      children: [
+        SizedBox(width: 80, child: Text(label)),
+        SizedBox(
+          width: 60,
+          height: 24,
+          child: OscPathSegment(
+            segment: segment,
+            child: NumericSlider(
+              key: key,
+              value: 0.0,
+              range: const RangeValues(0, 1),
+              detents: const [0.0, 1.0],
+              precision: 3,
+              onChanged: (v) {},
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        GestureDetector(
+          onTap: () => key.currentState?.setValue(0.0, immediate: true),
+          child: const Icon(Icons.refresh, size: 16),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final _pHKey = GlobalKey<NumericSliderState>();
+    final _pVKey = GlobalKey<NumericSliderState>();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            const SizedBox(width: 80, child: Text('LTI')),
+            OscPathSegment(segment: 'lti', child: const OscCheckbox()),
+            const SizedBox(width: 32),
+            const SizedBox(width: 80, child: Text('CTI')),
+            OscPathSegment(segment: 'cti', child: const OscCheckbox()),
+          ],
+        ),
+        const SizedBox(height: 8),
+        _sliderRow('Peaking H', 'peakingH', _pHKey),
+        const SizedBox(height: 8),
+        _sliderRow('Peaking V', 'peakingV', _pVKey),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            const SizedBox(width: 80, child: Text('Color Enhance')),
+            OscPathSegment(
+              segment: 'color_enhance',
+              child: const OscCheckbox(),
+            ),
+            const SizedBox(width: 32),
+            const SizedBox(width: 80, child: Text('Front NR')),
+            OscPathSegment(segment: 'front_nr', child: const OscCheckbox()),
+          ],
+        ),
+        const SizedBox(height: 8),
+        const Text('Front NR Y Coef'),
+        const _FloatArrayEditor(segment: 'front_nr_ycoef', length: 8),
+        const SizedBox(height: 8),
+        const Text('Front NR C Coef'),
+        const _FloatArrayEditor(segment: 'front_nr_ccoef', length: 4),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            const SizedBox(width: 80, child: Text('Block NR')),
+            const AbsoluteOscCheckbox(address: '/block_nr'),
+          ],
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `SendTexture` widget with numeric sliders and checkboxes for texture parameters
- add absolute OSC checkbox for `/block_nr`
- include the texture controls on each `SendPage`
- fix float array layout using a Wrap widget

## Testing
- `dart format lib/send_texture.dart lib/send_page.dart`
- `flutter analyze` *(fails to resolve local package)*

------
https://chatgpt.com/codex/tasks/task_e_686b96943e74832abf0abd8115d16b5f