### PR TITLE
Fix full array OSC send for Noise Reduction coefficients

### DIFF
--- a/lib/send_texture.dart
+++ b/lib/send_texture.dart
@@ -191,6 +191,7 @@ class _FloatArrayEditorState extends State<_FloatArrayEditor> {
               range: const RangeValues(0, 1),
               precision: 3,
               onChanged: (v) => _onChanged(i, v),
+              sendOsc: false,
             ),
           );
         }),


### PR DESCRIPTION
## Summary
- add `sendOsc` flag to `NumericSlider` to control OSC transmission
- use `sendOsc: false` for `front_nr` coefficient editors

## Testing
- `dart format lib/numeric_slider.dart lib/send_texture.dart`
- `flutter analyze` *(fails: could not find package osc)*

------
https://chatgpt.com/codex/tasks/task_e_686c687e4cfc832ab6dc28430bdaae05